### PR TITLE
Disable littlecms optimization to prevent (out-of-gammut) pure-white highlights

### DIFF
--- a/colorpal/jni/com_pushd_ColorPal.cpp
+++ b/colorpal/jni/com_pushd_ColorPal.cpp
@@ -112,7 +112,7 @@ JNIEXPORT jlong JNICALL Java_com_pushd_colorpal_ColorCorrector_createTransform(J
                                                   hOutputProfile,
                                                   TYPE_RGBA_8,
                                                   INTENT_PERCEPTUAL,
-                                                  cmsFLAGS_NOCACHE);
+                                                  cmsFLAGS_NOCACHE|cmsFLAGS_NOOPTIMIZE);
 
     if (!hTransform) {
         throwAssertionError(env, "Could not create transform");


### PR DESCRIPTION
When doing correction for profiles of extremely tinted displays, some of the out-of-gammut colors are mapped to pure white, which renders as the natural lcd tint instead of the intended white(ish). After playing with Color Translator MINI + jpegicc it seemed this pure white mapping would disappear when using 'higher accuracy' settings for the transform, which translates to the flag `cmsFLAGS_NOOPTIMIZE` 